### PR TITLE
try to fix offline charging and workaround

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -40,14 +40,16 @@ on charger
     # Setup zram options
     write /sys/block/zram0/comp_algorithm lz4
 
-service charger /sbin/healthd -c
+service charger /sbin/charger
     class charger
-    critical
-    seclabel u:r:healthd:s0
+    seclabel u:r:charger:s0
 
 on init
     # Support legacy paths
     symlink /sdcard /storage/sdcard0
+    
+    #Workaround for HardCoded Vendor blobs // Check is that is correct or if its the other way around
+    symlink /system/vendor /vendor 
 
     mkdir /sns/cal/ 0755 system system
     mkdir /sns/fingerprint 0775 system system


### PR DESCRIPTION
treble uses /vendor but some of our blobs have a hardcoded path to /system/vendor so we symlink them to work this around